### PR TITLE
Allow Control Panel to launch alternative RTF editors if WordPad is not present

### DIFF
--- a/src/apps/Rebound.ControlPanel/Views/WindowsToolsPage.xaml.cs
+++ b/src/apps/Rebound.ControlPanel/Views/WindowsToolsPage.xaml.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml.Controls;
 using Rebound.Core;
 using Rebound.Core.IPC;
+using Rebound.Core.Native.Helpers;
 using Rebound.Core.Native.Windows;
 using System;
 using System.Collections.Generic;
@@ -40,6 +41,28 @@ internal partial class Tool
             catch
             {
 
+            }
+        }
+        else if (name == "wordpad")
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo()
+                {
+                    FileName = "wordpad",
+                    UseShellExecute = true,
+                    Verb = "runas"
+                });
+            }
+            catch
+            {
+                string rtfexe = RegistryHelper.GetString(1, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts\\.rtf\\OpenWithList", "a");
+                Process.Start(new ProcessStartInfo()
+                {
+                    FileName = rtfexe,
+                    UseShellExecute = true,
+                    Verb = "runas"
+                });
             }
         }
         else if (name == "run")

--- a/src/core/Rebound.Core.Native/Helpers/RegistryHelper.cs
+++ b/src/core/Rebound.Core.Native/Helpers/RegistryHelper.cs
@@ -10,7 +10,7 @@ namespace Rebound.Core.Native.Helpers;
 
 public static class RegistryHelper
 {
-    public static unsafe string GetString(int HKEYType, char* SubKey, string ValueName)
+    public static unsafe string GetString(int HKEYType, string subKey, string ValueName)
     {
         var hKeyRoot = HKEYType switch
         {
@@ -22,9 +22,10 @@ public static class RegistryHelper
             _ => HKEY.HKEY_LOCAL_MACHINE, // using HKEY_LOCAL_MACHINE as default case as that's where most important registry values are stored
         };
 
+        using ManagedPtr<char> lpSubKey = subKey;
         using ManagedPtr<char> lpValueName = ValueName;
         HKEY hKey = default;
-        var status = RegOpenKeyExW(hKeyRoot, SubKey, 0, KEY.KEY_READ, &hKey);
+        var status = RegOpenKeyExW(hKeyRoot, lpSubKey, 0, KEY.KEY_READ, &hKey);
         if (status != TerraFX.Interop.Windows.ERROR.ERROR_SUCCESS)
             return null;
         try

--- a/src/core/Rebound.Core.Native/Helpers/RegistryHelper.cs
+++ b/src/core/Rebound.Core.Native/Helpers/RegistryHelper.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (C) Ivirius(TM) Community 2020 - 2026. All Rights Reserved.
+// Licensed under the MIT License.
+
+using Rebound.Core.Native.Wrappers;
+using System.Runtime.InteropServices;
+using TerraFX.Interop.Windows;
+using static TerraFX.Interop.Windows.Windows;
+
+namespace Rebound.Core.Native.Helpers;
+
+public static class RegistryHelper
+{
+    public static unsafe string GetString(int HKEYType, char* SubKey, string ValueName)
+    {
+        var hKeyRoot = HKEYType switch
+        {
+            0 => HKEY.HKEY_CLASSES_ROOT,
+            1 => HKEY.HKEY_CURRENT_USER,
+            2 => HKEY.HKEY_LOCAL_MACHINE,
+            3 => HKEY.HKEY_USERS,
+            4 => HKEY.HKEY_CURRENT_CONFIG,
+            _ => HKEY.HKEY_LOCAL_MACHINE, // using HKEY_LOCAL_MACHINE as default case as that's where most important registry values are stored
+        };
+
+        using ManagedPtr<char> lpValueName = ValueName;
+        HKEY hKey = default;
+        var status = RegOpenKeyExW(hKeyRoot, SubKey, 0, KEY.KEY_READ, &hKey);
+        if (status != TerraFX.Interop.Windows.ERROR.ERROR_SUCCESS)
+            return null;
+        try
+        {
+            uint type = 0;
+            uint cbData = 0;
+
+            // Query first for buffer size requirements
+            status = RegQueryValueExW(hKey, lpValueName, null, &type, null, &cbData);
+
+            if (status == TerraFX.Interop.Windows.ERROR.ERROR_FILE_NOT_FOUND)
+                return null;
+            if (status is not TerraFX.Interop.Windows.ERROR.ERROR_SUCCESS and not TerraFX.Interop.Windows.ERROR.ERROR_MORE_DATA)
+                return null;
+
+            // Allocate buffer on native heap (cbData is in bytes)
+            byte* pBuffer = (byte*)NativeMemory.Alloc(cbData);
+            try
+            {
+                status = RegQueryValueExW(hKey, lpValueName, null, &type, pBuffer, &cbData);
+                if (status != TerraFX.Interop.Windows.ERROR.ERROR_SUCCESS) return null;
+
+                // Marshal string depending on data type (REG_SZ or REG_EXPAND_SZ)
+                return new string((char*)pBuffer, 0, (int)(cbData / sizeof(char))).TrimEnd('\0');
+            }
+            finally
+            {
+                NativeMemory.Free(pBuffer);
+            }
+        }
+        finally
+        {
+            _ = RegCloseKey(hKey);
+        }
+    }
+}


### PR DESCRIPTION
Since Windows 11, version 24H2, WordPad is no longer installed by default in clean installs. The Control Panel was hardcoded to launch the WordPad executable, but since it doesn't exist in these versions unless added by the user, the Control Panel crashes.
Thus it is probably a good idea to consider allowing the default RTF editor as set by the user to be launched instead of WordPad when it is not present.

This has been tested on my machine and confirmed working. It opens the editor with administrator privileges though I can change the code to launch with normal user privileges if required.

Here's a video demonstrating the fix, if needed

https://github.com/user-attachments/assets/26e43338-4bec-4a43-937b-8a9fb403872b

